### PR TITLE
Add Packer template with CentOS, Guest Additions and nvm

### DIFF
--- a/tools/packer/centos-cmd.json
+++ b/tools/packer/centos-cmd.json
@@ -1,0 +1,38 @@
+{
+  "provisioners": [{
+    "type": "shell",
+    "execute_command": "sudo {{.Vars}} bash {{.Path}}",
+    "scripts": [
+      "scripts/install-guest-additions.sh"
+    ]}, {
+    "type": "shell",
+    "execute_command": "{{.Vars}} bash {{.Path}}",
+    "scripts": [
+      "scripts/install-nvm.sh"
+    ]}
+  ],
+  "builders": [{
+    "vm_name": "nodeschool-vm",
+    "type": "virtualbox-iso",
+    "format": "ova",
+    "guest_os_type": "RedHat_64",
+    "iso_url": "http://ftp.pbone.net/pub/centos/7/isos/x86_64/CentOS-7.0-1406-x86_64-Minimal.iso",
+    "iso_checksum_type": "sha256",
+    "iso_checksum": "04e99a4f1a013b95a7ebc9a90ffa9ac64d28eb9872bc193fbd7c581ec9b6a360",
+    "hard_drive_interface": "sata",
+    "disk_size": "5000",
+    "headless": false,
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "guest_additions_mode": "upload",
+    "http_directory": "http",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter><wait>"
+    ],
+    "shutdown_command": "echo 'Packer says bye ;-)' | sudo /sbin/halt -p",
+    "vboxmanage": [
+      [ "modifyvm", "{{.Name}}", "--memory", "512" ],
+      [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+    ]
+    }]
+}

--- a/tools/packer/http/ks.cfg
+++ b/tools/packer/http/ks.cfg
@@ -1,0 +1,73 @@
+# More about kickstart script for Centos at:
+# https://www.centos.org/docs/5/html/Installation_Guide-en-US/s1-kickstart2-file.html
+
+## Kickstart options
+
+install
+cdrom
+repo --name base --baseurl=http://ftp.pbone.net/pub/centos/7/os/x86_64/
+repo --name updates --baseurl=http://ftp.pbone.net/pub/centos/7/updates/x86_64/
+repo --name epel --baseurl=https://dl.fedoraproject.org/pub/epel/7/x86_64/
+
+lang pl_PL.UTF-8
+keyboard pl
+network --onboot yes --device eth0 --bootproto dhcp --noipv6
+# Root password, allows to be consistent with with Vagrant requirements
+rootpw --plaintext vagrant
+firewall --enabled --service=ssh
+authconfig --enableshadow --passalgo=sha512
+# We don't need SELinux on workshop machines
+selinux --disabled
+timezone Europe/Warsaw
+bootloader --location=mbr --driveorder=sda --append="crashkernel=auto rhgb quiet"
+
+# Perform installation in text mode
+text
+# Skips X configuration
+skipx
+
+zerombr
+clearpart --all --initlabel
+autopart
+
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot
+
+## Packages to be installed
+
+%packages
+@core
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+sudo
+bzip2
+kernel-devel
+kernel-headers
+gcc
+gcc-c++
+wget
+git
+
+### workshopper dependencies
+# - shader-school (node-canvas)
+cairo
+cairo-devel
+cairomm-devel
+libjpeg-turbo-devel
+pango
+pango-devel
+pangomm
+pangomm-devel
+giflib-devel
+
+%end
+
+%post
+/usr/sbin/groupadd -g 501 vagrant
+/usr/sbin/useradd vagrant -u 501 -g vagrant -G wheel
+echo "vagrant" | passwd --stdin vagrant
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
+%end

--- a/tools/packer/scripts/install-guest-additions.sh
+++ b/tools/packer/scripts/install-guest-additions.sh
@@ -1,0 +1,5 @@
+mkdir /mnt/guest
+mount -o loop /home/vagrant/VBoxGuestAdditions.iso /mnt/guest
+sh /mnt/guest/VBoxLinuxAdditions.run
+umount /mnt/guest
+rm -rf /home/vagrant/VBoxGuestAdditions.iso /mnt/guest

--- a/tools/packer/scripts/install-nvm.sh
+++ b/tools/packer/scripts/install-nvm.sh
@@ -1,0 +1,5 @@
+curl https://raw.githubusercontent.com/creationix/nvm/v0.24.0/install.sh | bash
+source ~/.nvm/nvm.sh
+nvm install 0.12 # for 'shader-school'
+nvm install iojs
+nvm alias default iojs


### PR DESCRIPTION
Podstawowy template Packera tworzy plik OVA z CentOS'em 7 (tylko CLI) do zaimportowania w VirtualBox. Zainstalowane zostały `iojs` oraz `0.12`, domyślnie alias wskazuje na `iojs`.
Doinstalowano także natywne zależności wymagane przez workshoppery, a w szczególności `shader-school`, który swoją drogą wymaga nodejs `0.12` (w razie potrzemy można się przepiąć `nvm use 0.12`).

Baza pod #12.
