### PR TITLE
Alias and współdzielenie katalogów

### DIFF
--- a/tools/packer/README.md
+++ b/tools/packer/README.md
@@ -1,0 +1,14 @@
+Jak dokonfigurować wirtualną maszynę?
+-------------------------------------
+
+- Po zaimportowaniu obrazu OVA zmień ustawienia sieci i ustaw adapter na "Bridged"
+- Skonfiguruj współdzielony katalog, w którym będziesz trzymał źródła (odznacz read-only, zaznacz auto-mount)
+- Jeśli VM została wcześniej uruchomiona, zatrzymaj ją
+- Uruchom maszynę w trybie headless (trzymając SHIFT)
+- Aby poznać IP po uruchomieniu maszyny wykonaj w konsoli komendę:
+  VBoxManage guestproperty get nodeschool-vm /VirtualBox/GuestInfo/Net/0/V4/IP
+- Użyj klienta SSH (zalecamy PuTTY [1]) do zalogowania się na użytkownika vagrant (hasło: vagrant)
+
+Współdzielony zasób znajduje się w /media/sf_<nazwa_zasobu>
+
+[1] http://the.earth.li/~sgtatham/putty/latest/x86/putty.exe

--- a/tools/packer/scripts/install-guest-additions.sh
+++ b/tools/packer/scripts/install-guest-additions.sh
@@ -3,3 +3,5 @@ mount -o loop /home/vagrant/VBoxGuestAdditions.iso /mnt/guest
 sh /mnt/guest/VBoxLinuxAdditions.run
 umount /mnt/guest
 rm -rf /home/vagrant/VBoxGuestAdditions.iso /mnt/guest
+
+usermod -a -G vboxsf vagrant

--- a/tools/packer/scripts/install-nvm.sh
+++ b/tools/packer/scripts/install-nvm.sh
@@ -3,3 +3,8 @@ source ~/.nvm/nvm.sh
 nvm install 0.12 # for 'shader-school'
 nvm install iojs
 nvm alias default iojs
+
+# When enabled directory sharing with Windows host you operate on NTFS
+# and some modules might not be able to be installed because of symlink
+# creation not possible on NTFS.
+echo "alias npm='npm --no-bin-links'" >> ~/.bashrc


### PR DESCRIPTION
- PR rozwiązuje problem uprawnień przy współdzieleniu katalogów, 
- Dodaje alias `npm --no-bin-links'`
- Dodaje instrukcje do wykonania przez uczestników po imporcie
#12
